### PR TITLE
Fixes on windows. "fatal: Paths with -a does not make sense."

### DIFF
--- a/lib/piston/git/commit.rb
+++ b/lib/piston/git/commit.rb
@@ -62,7 +62,7 @@ module Piston
         
         Dir.chdir(@dir) do
           logger.debug {"Saving old changes before updating"}
-          git(:commit, '-a', '-m', 'old changes')
+          git(:commit, '-a', '-m', '"old changes"')
           target = commit
           target = "origin/#{target}" unless target.include?("/") || target =~ /^[a-f\d]+$/i
           logger.debug {"Merging old changes with #{target}"}

--- a/lib/piston/git/working_copy.rb
+++ b/lib/piston/git/working_copy.rb
@@ -98,7 +98,7 @@ module Piston
         Dir.chdir(path) do
           begin
             logger.debug {"Saving changes in temporary branch"}
-            git(:commit, '-a', '-m', 'merging')
+            git(:commit, '-a', '-m', '"merging"')
             logger.debug {"Return to previous branch"}
             git(:checkout, revision)
             logger.debug {"Merge changes from temporary branch"}


### PR DESCRIPTION
The following part fails on windows (piston update):
    git commit -a -m 'old changes'
which seems to be because of the single quotes. 
I'm not sure about my patch, but I quickly fixed the issue by adding double quotes to the commit message.
